### PR TITLE
prepopulate destination

### DIFF
--- a/zbobr-api/src/config.rs
+++ b/zbobr-api/src/config.rs
@@ -58,6 +58,14 @@ pub struct ZbobrDispatcherConfig {
     pub git_user_email: String,
     /// Rewrite commit authors after each stage completes to match configured git user.
     pub overwrite_author: bool,
+    /// Default destination repository pre-populated into task parameters before the
+    /// preparator agent runs (e.g. "owner/repo" or a full git URL). The preparator
+    /// may still override this value. When unset the agent must determine the
+    /// repository from the task description alone.
+    pub default_destination_repository: Option<String>,
+    /// Default destination branch pre-populated into task parameters before the
+    /// preparator agent runs (e.g. "main"). The preparator may still override this.
+    pub default_destination_branch: Option<String>,
 }
 
 impl Default for ZbobrDispatcherConfig {
@@ -77,6 +85,8 @@ impl Default for ZbobrDispatcherConfig {
             git_user_name: String::new(),
             git_user_email: String::new(),
             overwrite_author: false,
+            default_destination_repository: None,
+            default_destination_branch: None,
         }
     }
 }

--- a/zbobr-dispatcher/src/cli.rs
+++ b/zbobr-dispatcher/src/cli.rs
@@ -874,7 +874,9 @@ impl<'a> CliRoleRunner<'a> {
 
         let work_dir = prepare_workspace(self.zbobr, self.task_id, self.role, &task_dir).await?;
 
-        if !matches!(self.role, Role::Preparator) {
+        if matches!(self.role, Role::Preparator) {
+            seed_preparator_defaults(self.zbobr, self.task_id).await?;
+        } else {
             ensure_pr_url(self.zbobr, self.task_id).await?;
         }
 
@@ -1303,6 +1305,36 @@ async fn ensure_pr_url(zbobr: &ZbobrDispatcherDyn, task_id: u64) -> anyhow::Resu
             Err(anyhow::anyhow!(msg))
         }
     }
+}
+
+/// Pre-populate task parameters from dispatcher config defaults before the
+/// preparator agent runs. Only sets a parameter if it is not already present,
+/// so a previously prepared task (e.g. re-run) keeps its values unchanged.
+async fn seed_preparator_defaults(
+    zbobr: &ZbobrDispatcherDyn,
+    task_id: u64,
+) -> anyhow::Result<()> {
+    let config = zbobr.config();
+    let task = zbobr.get_task(task_id).await?;
+    let role_session = zbobr.role_session(task_id);
+
+    if let Some(default_repo) = &config.default_destination_repository {
+        if !task.parameters.contains_key(&Parameter::DestinationRepository) {
+            role_session
+                .set_parameter(Parameter::DestinationRepository, Some(default_repo.clone()))
+                .await?;
+        }
+    }
+
+    if let Some(default_branch) = &config.default_destination_branch {
+        if !task.parameters.contains_key(&Parameter::DestinationBranch) {
+            role_session
+                .set_parameter(Parameter::DestinationBranch, Some(default_branch.clone()))
+                .await?;
+        }
+    }
+
+    Ok(())
 }
 
 fn should_try_early_merge(role: Role) -> bool {

--- a/zbobr-dispatcher/src/mcp/instructions.rs
+++ b/zbobr-dispatcher/src/mcp/instructions.rs
@@ -29,10 +29,11 @@ Read the task description and set the required parameters for the implementation
 1. Call `{GET_DESCRIPTION}` to read the user task description
 2. Call `{GET_DISCUSSION}` for context and prior comments
 3. **Set task parameters** that will guide the implementation:
-    - Call `{SET_PARAM_DESTINATION_REPOSITORY}` with the target repository (full git URL, local path, or owner/repo format)
-    - Call `{SET_PARAM_DESTINATION_BRANCH}` (e.g., "main", "develop")
+    - Call `{GET_PARAM_DESTINATION_REPOSITORY}` and `{GET_PARAM_DESTINATION_BRANCH}` first — they may already be pre-populated with defaults from the configuration. Keep the defaults unless the task description clearly specifies a different repository or branch.
+    - Call `{SET_PARAM_DESTINATION_REPOSITORY}` only if the value is missing or incorrect (full git URL, local path, or owner/repo format)
+    - Call `{SET_PARAM_DESTINATION_BRANCH}` only if the value is missing or incorrect (e.g., "main", "develop")
     - Call `{SET_PARAM_WORK_BRANCH_POSTFIX}` with the work branch postfix (e.g., "implement-feature") — the full work branch will be formed from prefix, task id and this postfix
-    - Use `{GET_PARAM_DESTINATION_REPOSITORY}`, `{GET_PARAM_DESTINATION_BRANCH}`, `{GET_PARAM_WORK_BRANCH}` to read current values
+    - Use `{GET_PARAM_WORK_BRANCH}` to confirm the resulting work branch name
 4. Call `{REPORT_RESULTS}` to provide a brief and concise report of your work and finish the session. This report takes part in the context for further agent calls, so it MUST be compact.
 5. When finished, the task will move to the planning stage.
 "#,

--- a/zbobr-fs.toml
+++ b/zbobr-fs.toml
@@ -3,6 +3,9 @@ workspaces = "./workspaces"
 git_user_name = "Copilot"
 git_user_email = "copilot@example.com"
 cli_tool = "copilot"
+# Default destination repository pre-populated for preparator agent (e.g. "owner/repo")
+# default_destination_repository = "milyin/zbobr"
+# default_destination_branch = "main"
 
 [tasks]
 # Filesystem task backend settings

--- a/zbobr.toml
+++ b/zbobr.toml
@@ -3,6 +3,9 @@ workspaces = "./workspaces"
 git_user_name = "Copilot"
 git_user_email = "copilot@example.com"
 cli_tool = "copilot"
+# Default destination repository pre-populated for preparator agent (e.g. "owner/repo")
+# default_destination_repository = "milyin/zbobr"
+# default_destination_branch = "main"
 
 [repo.github]
 # GitHub repo backend settings


### PR DESCRIPTION
if all tasks related to the same repo, specify them explicitly instead of making agent guessing