### PR TITLE
The problem was that octocrab.delete() tries to deserialize the respo…

### DIFF
--- a/zbobr-task-backend-github/src/github.rs
+++ b/zbobr-task-backend-github/src/github.rs
@@ -452,10 +452,10 @@ impl ZbobrTaskBackendGithubImpl {
         let (owner, repo) = self.parse_repo()?;
         let url = format!("/repos/{owner}/{repo}/labels/{name}");
         retry_github("delete label", || {
-            self.octocrab.delete(url.clone(), None::<&()>)
+            self.octocrab._delete(url.clone(), None::<&()>)
         })
         .await
-        .map(|_: serde_json::Value| ())?;
+        .map(|_| ())?;
         Ok(())
     }
 


### PR DESCRIPTION
…nse body as JSON, but GitHub's

  DELETE /repos/{owner}/{repo}/labels/{name} returns 204 No Content (empty body). This caused an EOF JSON parse error, which
   was classified as transient, triggering a retry — but the label was already deleted, so the retry got a 404.

  Fix: Changed self.octocrab.delete(...) to self.octocrab._delete(...), which returns a raw Response instead of trying to
  deserialize JSON from an empty body.